### PR TITLE
loadable: avoid omitting children to be able to pass complex components

### DIFF
--- a/src/HOC/loadable.tsx
+++ b/src/HOC/loadable.tsx
@@ -19,7 +19,7 @@ const loadableFactory = (
 ) => (LoadableComponent: React.ComponentType) => {
     const ComponentWithLoader: React.FunctionComponent<WithLoaderProps> = ({ showLoader, loaderText, ...props }) => (
         <LoaderComponent show={showLoader} text={loaderText}>
-            <LoadableComponent {...omit(props, ['children'])} />
+            <LoadableComponent {...props} />
         </LoaderComponent>
     );
 

--- a/src/HOC/loadable.tsx
+++ b/src/HOC/loadable.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import getDisplayName from 'react-display-name';
-import { omit } from 'lodash';
 
 interface LoaderComponentProps {
     show: boolean;


### PR DESCRIPTION
Avoid omitting children prop since it makes passing complex components impossible.