### PR TITLE
Fix/make dropzone

### DIFF
--- a/src/HOC/makeDropzone.tsx
+++ b/src/HOC/makeDropzone.tsx
@@ -4,7 +4,7 @@ import ReactDropzone from 'react-dropzone';
 import { Subtract } from 'utility-types';
 import { identity } from 'lodash';
 
-enum FS {
+export enum FS {
     failed = -1,
     pending = 0,
     uploading = 1,
@@ -133,9 +133,10 @@ function makeDropzone<WrappedProps extends InjectedProps>(DropzoneGraphic: React
                             onDrop={this.onDrop}
                             onDragEnter={() => null}
                             onDragOver={this.handleDragOver}
-                            onDragLeave={this.handleDragLeave}>
-                            {({getRootProps, getInputProps}) => (
-                                <div {...getRootProps({role: 'button'})}>
+                            onDragLeave={this.handleDragLeave}
+                        >
+                            {({ getRootProps, getInputProps }) => (
+                                <div {...getRootProps({ role: 'button' })}>
                                     <input {...getInputProps(input)} />
                                     <DropzoneGraphic
                                         isMouseOver={this.state.mouseOver}
@@ -152,6 +153,6 @@ function makeDropzone<WrappedProps extends InjectedProps>(DropzoneGraphic: React
     };
 }
 
-makeDropzone .FS = FS;
+makeDropzone.FS = FS;
 
-export default makeDropzone as typeof makeDropzone && { FS: typeof FS };
+export default makeDropzone;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9713,7 +9713,7 @@ react-dom@16.8.x:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-dom@^16.8, react-dom@^16.8.3:
+react-dom@^16.8.3:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -9910,7 +9910,7 @@ react@16.8.x:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react@^16.8, react@^16.8.3:
+react@^16.8.3:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
### Issue
So I am using the `makeDropzone` on some project as:
<img width="545" alt="Snímek obrazovky 2021-11-25 v 13 31 16" src="https://user-images.githubusercontent.com/25985035/143443952-90b807b3-d7e9-4e75-8b38-a392f25d4d1b.png">
and after upgrading to `v0.4.0` I am getting this error:
![Snímek obrazovky 2021-11-25 v 13 31 24](https://user-images.githubusercontent.com/25985035/143443995-918d52e7-b845-40c8-8578-26738d8ea280.png)

---

### Solution
There's a syntax issue in the export. Also, the code was not formatted so I formatted with prettier. 